### PR TITLE
Remove "mediawiki.ui/variables.less"

### DIFF
--- a/modules/search/css/styles.less
+++ b/modules/search/css/styles.less
@@ -1,5 +1,4 @@
 @import 'mediawiki.skin.variables.less';
-@import 'mediawiki.ui/variables.less';
 
 @import './components/Control.less';
 @import './components/Results.less';


### PR DESCRIPTION
It has been deprecated since MW 1.41 and removed in MW 1.43 and thus now throws an error.