### PR TITLE
Fixes for MediaWiki 1.44

### DIFF
--- a/includes/Content/DataConstraints/AssociationStringGroupExistsConstraint.php
+++ b/includes/Content/DataConstraints/AssociationStringGroupExistsConstraint.php
@@ -2,7 +2,6 @@
 namespace MediaWiki\Extension\DataMaps\Content\DataConstraints;
 
 use MediaWiki\Extension\DataMaps\Content\MapVersionInfo;
-use Status;
 use stdClass;
 
 class AssociationStringGroupExistsConstraint extends DataConstraint {

--- a/includes/Content/DataConstraints/DeprecationConstraint.php
+++ b/includes/Content/DataConstraints/DeprecationConstraint.php
@@ -2,7 +2,6 @@
 namespace MediaWiki\Extension\DataMaps\Content\DataConstraints;
 
 use MediaWiki\Extension\DataMaps\Content\MapVersionInfo;
-use Status;
 use stdClass;
 
 class DeprecationConstraint extends DataConstraint {

--- a/includes/Content/DataConstraints/MarkerUidNoOverlapConstraint.php
+++ b/includes/Content/DataConstraints/MarkerUidNoOverlapConstraint.php
@@ -2,7 +2,6 @@
 namespace MediaWiki\Extension\DataMaps\Content\DataConstraints;
 
 use MediaWiki\Extension\DataMaps\Content\MapVersionInfo;
-use Status;
 use stdClass;
 
 class MarkerUidNoOverlapConstraint extends DataConstraint {

--- a/includes/Content/DataConstraints/RequiredFilesConstraint.php
+++ b/includes/Content/DataConstraints/RequiredFilesConstraint.php
@@ -1,13 +1,12 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Content\DataConstraints;
 
-use Html;
 use MediaWiki\Extension\DataMaps\Content\MapVersionInfo;
 use MediaWiki\Extension\DataMaps\Content\StatusUtils;
 use MediaWiki\Extension\DataMaps\Rendering\Utils\DataMapFileUtils;
-use SpecialPage;
+use MediaWiki\SpecialPage\SpecialPage;
+use MediaWiki\Title\Title;
 use stdClass;
-use Title;
 
 class RequiredFilesConstraint extends DataConstraint {
     private const MESSAGE = 'datamap-validate-constraint-requiredfile';

--- a/includes/Content/DataMapContentHandler.php
+++ b/includes/Content/DataMapContentHandler.php
@@ -145,7 +145,8 @@ class DataMapContentHandler extends JsonContentHandler {
         // Render the map if this is not a fragment
         if ( $isGood && !$content->isFragment() ) {
             $parser = MediaWikiServices::getInstance()->getParser();
-            $embed = $content->getEmbedRenderer( $pageRef, $parser, $parserOutput, [
+            $title = Title::newFromPageReference( $pageRef );
+            $embed = $content->getEmbedRenderer( $title, $parser, $parserOutput, [
                 'inlineData' => $parserOptions->getIsPreview(),
             ] );
             $embed->prepareOutput( $parserOutput );

--- a/includes/Content/JsonSchemaEx/UndefinedConstraintEx.php
+++ b/includes/Content/JsonSchemaEx/UndefinedConstraintEx.php
@@ -9,10 +9,8 @@
 
  namespace MediaWiki\Extension\DataMaps\Content\JsonSchemaEx;
 
-use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Exception\ValidationException;
-use JsonSchema\Uri\UriResolver;
 use JsonSchema\Constraints\UndefinedConstraint;
 
 /**

--- a/includes/Data/CoordinateSystem.php
+++ b/includes/Data/CoordinateSystem.php
@@ -1,10 +1,6 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use MediaWiki\Extension\DataMaps\Rendering\Utils\DataMapColourUtils;
-use Status;
-use stdClass;
-
 class CoordinateSystem extends DataModel {
     protected static string $publicName = 'CoordinateSystem';
 

--- a/includes/Data/DataMapSpec.php
+++ b/includes/Data/DataMapSpec.php
@@ -1,12 +1,10 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use MediaWiki\Extension\DataMaps\Content\DataMapContent;
 use MediaWiki\Extension\DataMaps\ExtensionConfig;
 use MediaWiki\MediaWikiServices;
-use Status;
+use MediaWiki\Title\Title;
 use stdClass;
-use Title;
 
 class DataMapSpec extends DataModel {
     protected static string $publicName = 'DataMapSpec';

--- a/includes/Data/DataModel.php
+++ b/includes/Data/DataModel.php
@@ -1,10 +1,6 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use InvalidArgumentException;
-use MediaWiki\Extension\DataMaps\Rendering\Utils\DataMapColourUtils;
-use MediaWiki\Extension\DataMaps\Rendering\Utils\DataMapFileUtils;
-use Status;
 use stdClass;
 
 class DataModel {

--- a/includes/Data/LeafletSettingsSpec.php
+++ b/includes/Data/LeafletSettingsSpec.php
@@ -1,8 +1,6 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use Status;
-
 /**
  * Stub model with validation only.
  */

--- a/includes/Data/MapBackgroundOverlaySpec.php
+++ b/includes/Data/MapBackgroundOverlaySpec.php
@@ -2,7 +2,6 @@
 namespace MediaWiki\Extension\DataMaps\Data;
 
 use MediaWiki\Extension\DataMaps\Rendering\Utils\DataMapColourUtils;
-use Status;
 
 // TODO: this is kind of a mess, needs a rewrite
 

--- a/includes/Data/MapBackgroundSpec.php
+++ b/includes/Data/MapBackgroundSpec.php
@@ -1,8 +1,6 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use Status;
-
 class MapBackgroundSpec extends DataModel {
     protected static string $publicName = 'MapBackgroundSpec';
 

--- a/includes/Data/MapBackgroundTileSpec.php
+++ b/includes/Data/MapBackgroundTileSpec.php
@@ -1,8 +1,6 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use Status;
-
 class MapBackgroundTileSpec extends DataModel {
     protected static string $publicName = 'MapBackgroundTileSpec';
 

--- a/includes/Data/MapSettingsSpec.php
+++ b/includes/Data/MapSettingsSpec.php
@@ -2,7 +2,6 @@
 namespace MediaWiki\Extension\DataMaps\Data;
 
 use MediaWiki\Extension\DataMaps\Rendering\Utils\DataMapColourUtils;
-use Status;
 use stdClass;
 
 class MapSettingsSpec extends DataModel {

--- a/includes/Data/MarkerGroupSpec.php
+++ b/includes/Data/MarkerGroupSpec.php
@@ -1,9 +1,7 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use MediaWiki\Extension\DataMaps\ExtensionConfig;
 use MediaWiki\Extension\DataMaps\Rendering\Utils\DataMapColourUtils;
-use Status;
 use stdclass;
 
 class MarkerGroupSpec extends DataModel {

--- a/includes/Data/MarkerLayerSpec.php
+++ b/includes/Data/MarkerLayerSpec.php
@@ -1,7 +1,6 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use Status;
 use stdclass;
 
 class MarkerLayerSpec extends DataModel {

--- a/includes/Data/MarkerSpec.php
+++ b/includes/Data/MarkerSpec.php
@@ -1,8 +1,6 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use Status;
-
 class MarkerSpec extends DataModel {
     protected static string $publicName = 'MarkerSpec';
 

--- a/includes/Data/ZoomSettingsSpec.php
+++ b/includes/Data/ZoomSettingsSpec.php
@@ -1,8 +1,6 @@
 <?php
 namespace MediaWiki\Extension\DataMaps\Data;
 
-use Status;
-
 class ZoomSettingsSpec extends DataModel {
     protected static string $publicName = 'ZoomSettingsSpec';
 


### PR DESCRIPTION
Mostly namespacing `\Title` and `\SpecialPage`, which shouldn't be breaking 1.43. Also removed unused imports and fixed one instance of type mismatch (`PageReference` vs. `Title`).