### PR TITLE
Fix the "copy link" button on markers

### DIFF
--- a/modules/core/MarkerPopup.js
+++ b/modules/core/MarkerPopup.js
@@ -154,13 +154,14 @@ module.exports = class MarkerPopup {
         };
 
         if ( this.map.canModifyUriAddress() ) {
-            const getLink = createButton(
+            createButton(
                 'link',
                 'datamap-popup-marker-link-get',
                 CodexIcon.cdxIconLink,
                 () => {
+                    const /** @type {string} */ href = Util.makeUrlWithParams( this.map, { marker: this.uid }, true );
                     // eslint-disable-next-line compat/compat
-                    navigator.clipboard.writeText( /** @type {string} */ ( getLink.getAttribute( 'href' ) ) )
+                    navigator.clipboard.writeText( href )
                         .then( () => mw.notify( mw.msg( 'datamap-popup-marker-link-copied' ) ) );
                 }
             );


### PR DESCRIPTION
In https://github.com/wiki-gg-oss/mediawiki-extensions-DataMaps/commit/911bb7730fe8de34d85b7c86443cd7d3bb418536, the code that used to set the `href` attribute on the "copy link" has been removed, and so the button for copying the marker link copies "null" instead of the real link. This change fixes that.