### PR TITLE
Fix hard deprecations in MediaWiki 1.44

### DIFF
--- a/includes/Rendering/MarkerProcessor.php
+++ b/includes/Rendering/MarkerProcessor.php
@@ -164,11 +164,12 @@ class MarkerProcessor {
 
         // Call the parser
         $out = $this->parser->parse( $text, $this->title, $this->parserOptions, false, $this->isParserDirty )
-            ->getText( [
+            ->runOutputPipeline( $this->parserOptions, [
                 'unwrap' => true,
                 'allowTOC' => false,
                 'includeDebugInfo' => false
-            ] );
+            ] )
+            ->getContentHolderText();
         // Mark as clean to avoid clearing state again
         $this->isParserDirty = false;
 


### PR DESCRIPTION
There are three warnings being emitted by MediaWiki 1.44 for DataMaps right now:

- `ParserOutput::getText()`, hard deprecated in 1.44, removed in https://github.com/wikimedia/mediawiki/commit/199f372f1782308674ce0130ce0dfa95557c212d
- `ParserOutput::setPageProperty( $name, $value )` when the value is a string, hard deprecated in 1.44, removed in https://github.com/wikimedia/mediawiki/commit/ef8dfcf26bdbc74a0e59ccd275b8dd88c039fee5
- `Title::getPageViewLanguage()`, hard-deprecated in 1.43 but not removed yet.

This pull request synchronizes Scribunto's handling of documentation page parsing with DataMaps's, and removes the use of these deprecated methods.